### PR TITLE
Remove permissions.

### DIFF
--- a/rxandroidaudio/src/main/AndroidManifest.xml
+++ b/rxandroidaudio/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.github.piasy.rxandroidaudio">
 
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 </manifest>


### PR DESCRIPTION
```
 <uses-permission android:name="android.permission.RECORD_AUDIO"/>
    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
```
Hello, I think we should put this permission when an app's using record audio. 
You did a great job. Tks, 